### PR TITLE
Add condition for deleted file

### DIFF
--- a/SplFileInfo.php
+++ b/SplFileInfo.php
@@ -74,11 +74,14 @@ class SplFileInfo extends \SplFileInfo {
      */
     public function __construct ( $filename, $relativePath = null ) {
 
+        if(false === file_exists($filename))
+            return;
+
         parent::__construct($filename);
 
         $this->_hash = md5(
             $this->getPathname() .
-            ( $this->isFile() ? $this->getMTime() : 0 )
+            $this->getMTime()
         );
         $this->_relativePath = $relativePath;
 


### PR DESCRIPTION
Not throw RuntimeException: SplFileInfo::getMTime(): stat failed
When the file was already deleted by another parallel process.

@src: http://framework.zend.com/issues/browse/ZF-11858
I belive that this error occurs only under some load, when two (or more) process fire at the same time. One process tries to run SplFileInfo::getMTime() on file wich was already deleted by other parallel process.
Solution for this could be some kind of semaphore or at least an additional file_exists() check.
