### PR TITLE
Buffer: Make `current` & `key` methods inlinable

### DIFF
--- a/Buffer.php
+++ b/Buffer.php
@@ -138,9 +138,7 @@ class          Buffer
      */
     public function current()
     {
-        $current = $this->getBuffer()->current();
-
-        return $current[self::BUFFER_VALUE];
+        return $this->getBuffer()->current()[self::BUFFER_VALUE];
     }
 
     /**
@@ -150,9 +148,7 @@ class          Buffer
      */
     public function key()
     {
-        $current = $this->getBuffer()->current();
-
-        return $current[self::BUFFER_KEY];
+        return $this->getBuffer()->current()[self::BUFFER_KEY];
     }
 
     /**


### PR DESCRIPTION
By changing the code this way, the `current` and `key` methods are inlinable by the VM if such heuristics exist.